### PR TITLE
Don't override scope directory on instance load

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -321,7 +321,9 @@ class Program
       }
 
       ResourceText = System.IO.File.ReadAllText(filePath);
-      ScopeDirectory = System.IO.Path.GetDirectoryName(filePath);
+      if (ScopeDirectory == null) {
+        ScopeDirectory = System.IO.Path.GetDirectoryName(filePath);
+      }
     }
 
     public void LoadScopeDirectory(string text)


### PR DESCRIPTION
Hi! I really like your Hammer tool, but I ran into a bit of unexpected behavior when trying it out. We have our profiles and our instances in separate dirs, so I first set the scope directory to our profiles dir and then proceeded to load the instance from another dir. However, when loading the instance, the scope dir is set to the underlying dir of that instance and the profiles can't be found anymore.

My suggestion would be to only set the scope dir on instance loading if it is not already set explicitly.