### PR TITLE
Remove unused Domain and Organisation names

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -626,11 +626,7 @@ class Program
       using (var engine = new QQmlApplicationEngine())
       {
         Qml.Net.Qml.RegisterType<AppModel>("appmodel", 1, 0);
-
         engine.Load("Main.qml");
-
-        QCoreApplication.OrganizationDomain = "domain";
-        QCoreApplication.OrganizationName = "name";
 
         return app.Exec();
       }


### PR DESCRIPTION
They were only needed for the old dialog pickers, new ones don't require them.