### PR TITLE
Fix Java process hanging when it had a lot of debug text

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -502,8 +502,9 @@ class Program
 
         try
         {
-            validator.Start();
-            validator.WaitForExit();
+            validatorOutput = validator.StandardOutput.ReadToEnd();
+            validatorOutput += validator.StandardError.ReadToEnd();
+            validator.WaitForExit(1000 * 60 * 5);
         }
         catch (Exception ex)
         {
@@ -526,8 +527,6 @@ class Program
             }
             return result;
         }
-        validatorOutput = validator.StandardOutput.ReadToEnd();
-        validatorOutput += validator.StandardError.ReadToEnd();
 
         sw.Stop();
         Console.WriteLine($"Java validation performed in {sw.ElapsedMilliseconds}ms");


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.standardoutput?redirectedfrom=MSDN&view=netcore-2.2#System_Diagnostics_Process_StandardOutput "The example avoids a deadlock condition by calling p.StandardOutput.ReadToEnd before p.WaitForExit. A deadlock condition can result if the parent process calls p.WaitForExit before p.StandardOutput.ReadToEnd and the child process writes enough text to fill the redirected stream"